### PR TITLE
blender.nix: opencl-info -> clinfo

### DIFF
--- a/blender.nix
+++ b/blender.nix
@@ -13,7 +13,7 @@
       freeglut
       opencl-clang
       opencl-headers
-      opencl-info
+      clinfo
       openal
       libGL
       libGLU


### PR DESCRIPTION
opencl-info has been retired from nixpkgs and is not downloadable because the upstream is unmaintained. clinfo is the replacement package.